### PR TITLE
fix(stash): fix parallel studio creation race condition and base_path initialization

### DIFF
--- a/stash/processing/base.py
+++ b/stash/processing/base.py
@@ -122,6 +122,8 @@ class StashProcessingBase:
                 self.state.download_path = set_create_directory_for_download(
                     self.config, self.state
                 )
+                # Update base_path to use the created download_path for scanning
+                self.state.base_path = self.state.download_path
                 print_info(f"Created download path: {self.state.download_path}")
             except Exception as e:
                 print_error(f"Failed to create download path: {e}")


### PR DESCRIPTION
Fixes two critical bugs discovered during test migration:

1. Studio processing cache invalidation bug:
   - After failed studio creation, retry query was returning cached empty result
   - Added cache_clear() before retry to handle parallel processing race condition
   - Also fixed url→urls schema change to match upstream Stash API
   - Removed unnecessary sanitize_model_data() calls (client already deserializes)

2. Scan folder base_path initialization bug:
   - When base_path was None, code created download_path but didn't update base_path
   - This caused metadata_scan to try using None path, failing silently
   - Now properly sets base_path = download_path after successful creation

Both bugs were hidden by mock-based tests that worked around the issues. Edge mocking with respx exposed them during test refactoring.