### PR TITLE
Handle foreign and unique key constraints to avoid SQL error

### DIFF
--- a/alembic/versions/671bc5c3096d_add_unique_constraint_to_media_.py
+++ b/alembic/versions/671bc5c3096d_add_unique_constraint_to_media_.py
@@ -1,0 +1,26 @@
+"""add unique constraint to media_locations table
+
+Revision ID: 671bc5c3096d
+Revises: 0e79e34eea22
+Create Date: 2026-01-11 16:26:33.635906
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '671bc5c3096d'
+down_revision: str | None = '0e79e34eea22'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint('media_locations_mediaId_locationId_key', 'media_locations', ['mediaId', 'locationId'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('media_locations_mediaId_locationId_key', 'media_locations', type_='unique')

--- a/metadata/media.py
+++ b/metadata/media.py
@@ -441,6 +441,10 @@ async def _process_media_batch(
                 phase_name = "parent" if phase == 0 else "variant"
                 await _get_or_create_media(session, items, phase_name)
 
+        # Flush media records to database before processing relationships
+        # This ensures media IDs exist for foreign key constraints
+        await session.flush()
+
         # Process relationships
         await _sync_relationships(session, batch)
 


### PR DESCRIPTION
Fixes https://github.com/Jakan-Kink/fansly-scraper/issues/15 (at least for me)

There are 2 changes in the PR:
1. Add a unique key constraint on mediaId and locationId to the media table. This is required for https://github.com/Jakan-Kink/fansly-scraper/blob/main/metadata/media.py#L386 to work properly.
2. Flush the session before processing relationships to ensure foreign key constraints can be met 