### PR TITLE
fix: resolve InvalidRequestError in nested transactions

### DIFF
--- a/metadata/post.py
+++ b/metadata/post.py
@@ -420,7 +420,7 @@ async def _process_post_mentions(
     )
 
     await session.execute(stmt)
-    await session.commit()
+    await session.flush()
 
 
 async def _process_post_attachments(


### PR DESCRIPTION
Replaced explicit session.commit() with session.flush() in metadata/post.py to prevent premature transaction closure during nested operations (e.g., download_wall). This fixes the sqlalchemy.exc.InvalidRequestError.