### PR TITLE
fix: backfill truncated accountMedia in bundles >5 items

### DIFF
--- a/metadata/account.py
+++ b/metadata/account.py
@@ -9,8 +9,12 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING, Any
 
+from textio import json_output
+
+from .entity_store import PostgresEntityStore
 from .models import (
     Account,
+    AccountMedia,
     AccountMediaBundle,
     get_store,
 )
@@ -52,24 +56,101 @@ async def process_media_bundles_data(
 async def _process_single_bundle(
     bundle: dict,
     account_id: int,
-    config: FanslyConfig,  # noqa: ARG001
+    config: FanslyConfig,
 ) -> None:
     """Process a single media bundle.
 
     _prepare_bundle_data: converts bundleContent/accountMediaIds → accountMedia IDs
     _process_nested_cache_lookups: resolves preview → Media, accountMedia → AccountMedia
     _sync_associations: ordered junction (DELETE + re-INSERT with pos)
+
+    The Fansly API truncates accountMedia objects in timeline responses
+    when a bundle has >5 items (positions 0-4 present, 5+ dropped).
+    After model_validate, we detect missing IDs and backfill them via
+    a follow-up API call before saving (#63).
     """
     store = get_store()
     bundle.setdefault("accountId", account_id)
 
+    # Capture all accountMediaIds before model_validate resolves (and drops) them
+    all_media_ids = [int(mid) for mid in bundle.get("accountMediaIds", [])]
+
     bundle_obj = AccountMediaBundle.model_validate(bundle)
+
+    # Detect accountMedia truncation: IDs the API listed but didn't include
+    resolved_ids = {am.id for am in bundle_obj.accountMedia}
+    missing_ids = [mid for mid in all_media_ids if mid not in resolved_ids]
+
+    if missing_ids:
+        await _backfill_missing_account_media(
+            config,
+            store,
+            bundle_obj,
+            missing_ids,
+        )
 
     # Save preview Media first if resolved (FK constraint)
     if bundle_obj.preview:
         await store.save(bundle_obj.preview)
 
     await store.save(bundle_obj)
+
+
+async def _backfill_missing_account_media(
+    config: FanslyConfig,
+    store: PostgresEntityStore,
+    bundle_obj: AccountMediaBundle,
+    missing_ids: list[int],
+) -> None:
+    """Fetch truncated accountMedia from API and attach to bundle.
+
+    The Fansly API truncates accountMedia in timeline/message responses
+    at 5 items per bundle. This fetches the missing items, processes
+    them through the normal Pydantic pipeline, and appends them to the
+    bundle so the junction table gets all positions.
+    """
+    from .media import process_media_info
+
+    json_output(
+        1,
+        "meta/account - backfill_truncated_bundle",
+        {
+            "bundleId": bundle_obj.id,
+            "missing_count": len(missing_ids),
+            "missing_ids": missing_ids,
+        },
+    )
+
+    try:
+        api = config.get_api()
+        media_ids_str = ",".join(str(mid) for mid in missing_ids)
+        response = api.get_account_media(media_ids_str)
+        media_infos = api.get_json_response_contents(response)
+    except Exception:
+        json_output(
+            2,
+            "meta/account - backfill_api_error",
+            {"bundleId": bundle_obj.id, "missing_ids": missing_ids},
+        )
+        return
+
+    # Process through normal pipeline → populates identity map cache
+    await process_media_info(config, {"batch": media_infos})
+
+    # Re-resolve from cache and append to bundle
+    for mid in missing_ids:
+        cached = store.get_from_cache(AccountMedia, mid)
+        if cached:
+            bundle_obj.accountMedia.append(cached)
+        else:
+            json_output(
+                2,
+                "meta/account - backfill_still_missing",
+                {"bundleId": bundle_obj.id, "accountMediaId": mid},
+            )
+
+    # Mark relationship dirty so save() syncs the junction table
+    bundle_obj.mark_dirty()
 
 
 async def process_media_bundles(

--- a/tests/metadata/integration/test_account_processing.py
+++ b/tests/metadata/integration/test_account_processing.py
@@ -2,11 +2,14 @@
 
 from datetime import UTC, datetime
 
+import httpx
 import pytest
+import respx
 
 from api.fansly import FanslyApi
 from metadata import (
     Account,
+    AccountMedia,
     AccountMediaBundle,
     Media,
     TimelineStats,
@@ -116,19 +119,135 @@ async def test_process_account_media_bundles(entity_store, mock_config, timeline
 
     account_id = account_data["id"]
 
-    # Pre-create required Media records that bundles reference
+    # Pre-create Media + AccountMedia records for all bundle items so that
+    # _process_single_bundle can resolve them from cache (no API backfill needed).
     for bundle in bundles_data:
-        for content in bundle.get("bundleContent", []):
-            media_id = content["accountMediaId"]
-            existing = await entity_store.get(Media, media_id)
+        for am_id in bundle.get("accountMediaIds", []):
+            media_id = snowflake_id()
+            existing = await entity_store.get(AccountMedia, am_id)
             if not existing:
-                await entity_store.save(Media(id=media_id, accountId=account_id))
+                existing_media = await entity_store.get(Media, media_id)
+                if not existing_media:
+                    await entity_store.save(Media(id=media_id, accountId=account_id))
+                await entity_store.save(
+                    AccountMedia(
+                        id=am_id,
+                        accountId=account_id,
+                        mediaId=media_id,
+                        createdAt=datetime.now(UTC),
+                    )
+                )
 
     # Process the bundles via production code
     await process_media_bundles(mock_config, account_id, bundles_data)
 
-    # Verify bundles were created
+    # Verify bundles were created with all media items
     for bundle_data in bundles_data:
         bundle_id = bundle_data["id"]
         bundle = await entity_store.get(AccountMediaBundle, bundle_id)
         assert bundle is not None
+        expected_count = len(bundle_data.get("accountMediaIds", []))
+        assert len(bundle.accountMedia) == expected_count
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_bundle_truncation_backfill(entity_store, config, fansly_api):
+    """Test that bundles with >5 items backfill truncated accountMedia via API.
+
+    The Fansly API truncates accountMedia objects at 5 items per bundle in
+    timeline responses. _process_single_bundle detects missing IDs and
+    fetches them via get_account_media() before saving the junction table.
+
+    Reproduces the pattern from issue #63.
+    """
+    store = entity_store
+
+    account_id = snowflake_id()
+    bundle_id = snowflake_id()
+
+    # 7 accountMedia items — first 5 "present" in response, last 2 "truncated"
+    am_ids = [snowflake_id() for _ in range(7)]
+    media_ids = [snowflake_id() for _ in range(7)]
+
+    # Set up the API on config
+    config._api = fansly_api
+
+    # Create prerequisite account
+    account = Account(id=account_id, username="truncation_test")
+    await store.save(account)
+
+    # Create all 7 Media records (FK target for AccountMedia.mediaId)
+    for mid in media_ids:
+        await store.save(Media(id=mid, accountId=account_id))
+
+    # Pre-cache only the first 5 AccountMedia (simulates what process_media_info
+    # would have done from the response's truncated accountMedia array)
+    for i in range(5):
+        am = AccountMedia(
+            id=am_ids[i],
+            accountId=account_id,
+            mediaId=media_ids[i],
+            createdAt=datetime.now(UTC),
+        )
+        await store.save(am)
+
+    # Mock the API call for the 2 missing accountMedia items
+    # get_with_ngsw does OPTIONS preflight + GET
+    respx.options(url__regex=r".*account/media.*").mock(
+        return_value=httpx.Response(200),
+    )
+    respx.get(url__regex=r".*account/media.*").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "success": True,
+                "response": [
+                    {
+                        "id": str(am_ids[5]),
+                        "accountId": str(account_id),
+                        "mediaId": str(media_ids[5]),
+                        "createdAt": int(datetime.now(UTC).timestamp()),
+                        "media": {
+                            "id": str(media_ids[5]),
+                            "accountId": str(account_id),
+                            "mimetype": "image/jpeg",
+                        },
+                    },
+                    {
+                        "id": str(am_ids[6]),
+                        "accountId": str(account_id),
+                        "mediaId": str(media_ids[6]),
+                        "createdAt": int(datetime.now(UTC).timestamp()),
+                        "media": {
+                            "id": str(media_ids[6]),
+                            "accountId": str(account_id),
+                            "mimetype": "image/jpeg",
+                        },
+                    },
+                ],
+            },
+        ),
+    )
+
+    # Bundle dict as it comes from the API — all 7 IDs listed,
+    # but only the first 5 are in the identity map cache
+    bundle_data = [
+        {
+            "id": bundle_id,
+            "accountId": account_id,
+            "createdAt": int(datetime.now(UTC).timestamp()),
+            "accountMediaIds": am_ids,  # all 7
+        }
+    ]
+
+    await process_media_bundles(config, account_id, bundle_data)
+
+    # Verify: bundle exists and junction table has all 7 positions
+    bundle = await store.get(AccountMediaBundle, bundle_id)
+    assert bundle is not None
+    assert len(bundle.accountMedia) == 7
+
+    # Verify ordering is preserved (junction table pos column)
+    junction_ids = [am.id for am in bundle.accountMedia]
+    assert junction_ids == am_ids


### PR DESCRIPTION
## Summary

Closes #63

- Fansly API silently truncates `accountMedia` objects at 5 items per bundle in timeline/message responses — `accountMediaIds` lists all IDs but the response only includes objects for positions 0–4
- `_process_single_bundle` now detects the gap after `model_validate` and backfills missing items via `get_account_media()` through the normal Pydantic pipeline before saving the junction table
- API failure degrades gracefully (logs warning, saves what resolved) rather than crashing the pipeline

## Test plan

- [x] `test_bundle_truncation_backfill` — 7-item bundle with only 5 cached, 2 fetched via respx-mocked API; verifies all 7 positions in junction table with correct ordering
- [x] `test_process_account_media_bundles` — fixed false positive (was passing because bug silently dropped IDs); now pre-creates AccountMedia and asserts complete junction
- [x] All 188 metadata tests pass
- [x] Verified against live DB (505 candidate bundles) — no existing data loss detected after prior full reprocess healed junction tables via the download path's individual fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)