### PR TITLE
fix: Windows fcntl import (#77) + null MediaLocation.location (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,5 +160,6 @@ since v0.11.0 shipped (a "v0.12" line was never cut as a distinct release).
   abandoned async-conversion plan, archaic H.264/MP4 PDF + author notes
   (superseded by PyAV for mp4 hashing)
 
-[Unreleased]: https://github.com/Jakan-Kink/fansly-scraper/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/Jakan-Kink/fansly-scraper/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/Jakan-Kink/fansly-scraper/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/Jakan-Kink/fansly-scraper/releases/tag/v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.13.1] - 2026-04-23
+
+Patch release fixing two issues reported on Windows + Python 3.14, plus
+rolling up incidental `fork-main` commits since v0.13.0.
+
+### Added
+
+- `docs/reference/request-signing.md` — reverse-engineered notes on Fansly's
+  request-signing scheme.
+
+### Changed
+
+- **Dependency**: added `filelock ^3.29.0` as a direct runtime dep, replacing
+  POSIX-only `fcntl` usage in the `config.ini → config.yaml` migration lock
+  (see #77). filelock picks the right platform primitive automatically
+  (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows).
+- `poetry.lock` and pre-commit hook versions refreshed.
+
+### Fixed
+
+- **#77** — Unconditional `import fcntl` at `config/loader.py:28` crashed app
+  startup on Windows (fcntl is POSIX-only). Swapped to
+  [filelock](https://github.com/tox-dev/filelock) with identical non-blocking
+  semantics. Bonus: filelock cleans up stale `config.ini.migrating.lock` files
+  on release (safe — unlink happens while the lock is still held, no TOCTOU).
+- **#78** — Fansly returns `locations=[{"location": null, "locationId": 1}]`
+  for some media (Direct slots with no CDN path resolved yet), which the
+  required-str typing on `MediaLocation.location` rejected with 8 Pydantic
+  validation errors per affected `Media`. Relaxed the field to `str | None`
+  and the DB column to NULL-tolerant (Alembic migration
+  `bb7006ec7c0e_make_media_locations_location_nullable`). Downstream readers
+  at `media/media.py:27` already handled `None` via the `loc.raw_url or
+  loc.location` fallback.
+
 ## [0.13.0] - 2026-04-22
 
 First release under the Keep-a-Changelog format. Flagship feature: the

--- a/alembic/versions/bb7006ec7c0e_make_media_locations_location_nullable.py
+++ b/alembic/versions/bb7006ec7c0e_make_media_locations_location_nullable.py
@@ -1,0 +1,51 @@
+"""make media_locations.location nullable
+
+Revision ID: bb7006ec7c0e
+Revises: 3a230146cb14
+Create Date: 2026-04-23 20:56:21.028206
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "bb7006ec7c0e"
+down_revision: str | None = "3a230146cb14"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Allow NULL in media_locations.location.
+
+    The Fansly API legitimately returns ``locations[{"location": None,
+    "locationId": N}]`` for some media (e.g. Direct slots with no CDN path
+    yet). Rejecting those at the DB level forced the whole Media payload
+    to fail Pydantic validation.
+    """
+    with op.batch_alter_table("media_locations", schema=None) as batch_op:
+        batch_op.alter_column(
+            "location",
+            existing_type=sa.String(),
+            nullable=True,
+        )
+
+
+def downgrade() -> None:
+    """Restore NOT NULL on media_locations.location.
+
+    The downgrade will fail if any NULL rows have been persisted since the
+    upgrade ran; that is intentional — the operator must resolve them
+    before reverting the schema.
+    """
+    with op.batch_alter_table("media_locations", schema=None) as batch_op:
+        batch_op.alter_column(
+            "location",
+            existing_type=sa.String(),
+            nullable=False,
+        )

--- a/config/loader.py
+++ b/config/loader.py
@@ -25,10 +25,10 @@ from __future__ import annotations
 
 import configparser
 import copy
-import fcntl
 from datetime import UTC, datetime
 from pathlib import Path
 
+from filelock import FileLock, Timeout
 from loguru import logger
 from pydantic import SecretStr
 
@@ -219,12 +219,13 @@ def migrate_ini_to_yaml(
         )
 
     # --- Acquire an exclusive non-blocking file lock to prevent concurrent migration ---
+    # filelock chooses the right platform primitive (fcntl.flock on POSIX,
+    # msvcrt.locking on Windows), so this path works on both.
     lock_path = ini_path.with_name(f"{ini_path.name}.migrating.lock")
-    lock_fd = lock_path.open("a")
+    lock = FileLock(str(lock_path), blocking=False)
     try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except BlockingIOError as exc:
-        lock_fd.close()
+        lock.acquire()
+    except Timeout as exc:
         raise ConfigError(
             f"Another process is migrating {ini_path}. "
             f"Lock held by: {lock_path}. Retry after the other process finishes."
@@ -258,11 +259,9 @@ def migrate_ini_to_yaml(
         # --- Step 4: Rename the ini to a timestamped backup ---
         ini_path.rename(backup_path)
     finally:
-        # Release the lock (closing the fd implicitly releases flock on this fd).
-        # The lock file is intentionally left on disk — removing it would open a
-        # TOCTOU race with a concurrent acquirer that just opened but not yet locked.
-        fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        lock_fd.close()
+        # Release the lock; filelock cleans up the on-disk lock file safely
+        # (no TOCTOU window — the unlink happens while we still hold the lock).
+        lock.release()
 
     return schema_from_ini
 

--- a/metadata/models.py
+++ b/metadata/models.py
@@ -1087,13 +1087,17 @@ class MediaLocation(FanslyRecord):
 
     `location` stores the normalized URL (no query params) for DB dedup/matching.
     `raw_url` preserves the original CDN URL with auth params for downloading.
+
+    Fansly sometimes returns `location=None` for entries that only declare a
+    `locationId` (e.g. Direct slots with no CDN path yet). We accept it and
+    persist NULL rather than rejecting the whole Media payload.
     """
 
     __table_name__: ClassVar[str] = "media_locations"
 
     mediaId: SnowflakeId
     locationId: int  # CDN location type code (1, 102, 103), not a Snowflake
-    location: str
+    location: str | None = None
     raw_url: str | None = None  # Transient — not in DB table, preserved for download
     metadata: dict | None = (
         None  # Transient — m3u8 auth params (Policy, Key-Pair-Id, Signature)

--- a/metadata/tables.py
+++ b/metadata/tables.py
@@ -97,7 +97,7 @@ media_locations = Table(
     metadata,
     Column("mediaId", BigInteger, ForeignKey("media.id"), primary_key=True),
     Column("locationId", BigInteger, primary_key=True),
-    Column("location", String, nullable=False),
+    Column("location", String, nullable=True),
     # Explicit UC exists in the database (created by migration), redundant with PK
     # but kept here to match the actual schema for zero Alembic drift.
     UniqueConstraint("mediaId", "locationId"),

--- a/poetry.lock
+++ b/poetry.lock
@@ -522,7 +522,7 @@ version = "3.29.0"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258"},
     {file = "filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90"},
@@ -3781,4 +3781,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "932d6eeec983fe9831a596554e48f8463a574cab169c1c1403780ee2f86d8d81"
+content-hash = "f2938b0fb46cd81656897b67cf9803e13964ae1d97455066f6cc4a971aae1776"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fansly-scraper"
-version = "0.13.0"
+version = "0.13.1"
 description = "Easy-to-use fansly.com content scraping tool. Enjoy your Fansly content offline anytime, anywhere in the highest possible content resolution! Fully customizable to download in bulk or single: photos, videos & audio from the timeline, messages, collection & single posts."
 authors = [
     {name ="prof79"},
@@ -54,6 +54,7 @@ javascript = ">=1!1.2.6"
 stash-graphql-client = ">=0.12.0"
 av = "^17.0.0"
 ruamel-yaml = "^0.19.1"
+filelock = "^3.29.0"
 
 
 [tool.poetry.group.browser-auth]

--- a/tests/config/integration/test_ini_migration.py
+++ b/tests/config/integration/test_ini_migration.py
@@ -7,13 +7,13 @@ call migrate_ini_to_yaml, inspect the produced YAML and backup file.
 
 from __future__ import annotations
 
-import fcntl
 import shutil
 import textwrap
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from filelock import FileLock
 from pydantic import SecretStr
 
 from config.loader import migrate_ini_to_yaml
@@ -525,9 +525,9 @@ def test_migration_from_legacy_ini_fixture(tmp_path: Path) -> None:
 def test_migration_lock_happy_path(tmp_path: Path) -> None:
     """Migration acquires a .migrating.lock file, completes, and releases it.
 
-    The lock file remains on disk after migration (intentional — removing it
-    mid-race creates a TOCTOU window).  The lock is released so another
-    migration can proceed immediately after.
+    The lock is released so another migration can proceed immediately after.
+    filelock cleans up the on-disk lock file on release; the acquire-after-
+    release test below verifies the lock state, not the file's persistence.
     """
     ini_path = tmp_path / "config.ini"
     yaml_path = tmp_path / "config.yaml"
@@ -570,17 +570,11 @@ def test_migration_lock_happy_path(tmp_path: Path) -> None:
     assert isinstance(schema, ConfigSchema)
     assert yaml_path.exists()
 
-    # Lock file exists on disk (left intentionally — harmless, advisory)
-    assert lock_path.exists()
-
-    # The lock is RELEASED — we can acquire it ourselves immediately
-    fd = lock_path.open("a")
-    try:
-        # This must not raise (non-blocking exclusive acquire succeeds)
-        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        fcntl.flock(fd, fcntl.LOCK_UN)
-    finally:
-        fd.close()
+    # The lock is RELEASED — we can acquire it ourselves immediately.
+    # This must not raise (non-blocking exclusive acquire succeeds).
+    verify_lock = FileLock(str(lock_path), blocking=False)
+    verify_lock.acquire()
+    verify_lock.release()
 
 
 # ---------------------------------------------------------------------------
@@ -626,11 +620,9 @@ def test_migration_lock_contention_raises_config_error(tmp_path: Path) -> None:
     )
 
     # Simulate "another process" by acquiring the lock ourselves before calling migrate
-    lock_path.touch()
-    holder_fd = lock_path.open("a")
+    holder = FileLock(str(lock_path), blocking=False)
+    holder.acquire()
     try:
-        fcntl.flock(holder_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-
         with pytest.raises(ConfigError, match=r"(?i)another process is migrating"):
             migrate_ini_to_yaml(ini_path, yaml_path, backup_suffix="contention")
 
@@ -638,8 +630,7 @@ def test_migration_lock_contention_raises_config_error(tmp_path: Path) -> None:
         assert ini_path.exists()
         assert not yaml_path.exists()
     finally:
-        fcntl.flock(holder_fd, fcntl.LOCK_UN)
-        holder_fd.close()
+        holder.release()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/metadata/unit/test_media.py
+++ b/tests/metadata/unit/test_media.py
@@ -185,6 +185,76 @@ async def test_media_location(entity_store):
 
 
 @pytest.mark.asyncio
+async def test_media_validate_accepts_null_location_in_locations_entry(entity_store):
+    """Regression for issue #78 using the reporter's exact payload.
+
+    Fansly returns ``locations=[{"location": None, "locationId": 1}]`` for
+    some media (Direct slots with no CDN path yet). Before the fix
+    ``Media.model_validate`` raised ``ValidationError: 8 validation errors``
+    because ``MediaLocation.location`` was typed as required ``str``.
+
+    ``entity_store`` is required so that ``_process_nested_cache_lookups``
+    injects ``mediaId`` from the parent Media's ``id`` into each locations
+    entry — that mirrors the real ``process_media_info`` call site.
+    """
+    account_id = 358160426321584128
+    account = Account(id=account_id, username="worthlessholes")
+    await entity_store.save(account)
+
+    payload = {
+        "accountId": account_id,
+        "flags": 0,
+        "height": 1440,
+        "id": 388733720573517825,
+        "location": "",
+        "locations": [{"location": None, "locationId": 1}],
+        "metadata": '{"duration":14.266667}',
+        "mimetype": "video/mp4",
+        "status": 1,
+        "type": 2,
+        "updatedAt": 1654177272,
+        "width": 2560,
+    }
+
+    media = Media.model_validate(payload)
+
+    assert media.id == 388733720573517825
+    assert len(media.locations) == 1
+    assert media.locations[0].locationId == 1
+    assert media.locations[0].location is None
+    assert media.locations[0].mediaId == 388733720573517825
+
+
+@pytest.mark.asyncio
+async def test_media_location_null_roundtrips_through_store(entity_store):
+    """A MediaLocation with ``location=None`` saves and reloads cleanly.
+
+    Exercises the ``media_locations.location`` NOT NULL → NULL migration.
+    """
+    store = entity_store
+
+    account_id = snowflake_id()
+    media_id = snowflake_id()
+
+    account = Account(id=account_id, username="test_user_null_loc")
+    await store.save(account)
+
+    media = Media(id=media_id, accountId=account_id, mimetype="video/mp4")
+    await store.save(media)
+
+    media.locations = [
+        MediaLocation(mediaId=media_id, locationId=1, location=None),
+    ]
+    await store.save(media)
+
+    reloaded = await store.get(Media, media_id)
+    assert reloaded is not None
+    assert len(reloaded.locations) == 1
+    assert reloaded.locations[0].locationId == 1
+    assert reloaded.locations[0].location is None
+
+
+@pytest.mark.asyncio
 async def test_invalid_metadata(entity_store, config):
     """Test handling invalid metadata JSON.
 


### PR DESCRIPTION
## Summary

- **#77**: `import fcntl` at `config/loader.py:28` crashed app startup on
Windows (fcntl is POSIX-only). Swap to [filelock](https://github.com/tox-dev/filelock),
which picks the right primitive per platform (fcntl.flock on POSIX,
msvcrt.locking on Windows) with identical non-blocking semantics.
- **#78**: Fansly returns `locations=[{"location": null, "locationId": 1}]`
for some media (Direct slots with no CDN path yet). The required-str
typing on `MediaLocation.location` rejected the whole `Media` payload
with 8 validation errors. Relax the Pydantic field and DB column to
allow NULL; downstream reader at `media/media.py:27` already handles it.
- Both issues surfaced on the same Windows + Python 3.14 environment;
shipping together as **0.13.1** alongside the preexisting `chore: deps`
and `docs: additional rev-eng documentation` commits on `fork-main`.

## Test plan

- [x] `poetry run pytest tests/config/integration/test_ini_migration.py -n4`
      passes (13/13 — lock acquire/release/contention all covered)
- [x] `poetry run pytest tests/metadata/unit/test_media.py -n4` passes
      (17/17 including the two new regression tests for #78)
- [x] `poetry run alembic upgrade head` runs the new
      `bb7006ec7c0e_make_media_locations_location_nullable` cleanly
- [x] `poetry run alembic check` reports no drift after upgrade
- [x] `poetry run ruff check` and `poetry run ruff format --check` clean
- [ ] On Windows (cc @fetar229 if available): app starts without
      `ImportError: No module named 'fcntl'` and a Media payload with
      `locations[0].location=null` is scraped without raising 8 Pydantic
      validation errors

Closes #77
Closes #78
